### PR TITLE
CVAR and map pool

### DIFF
--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -88,7 +88,7 @@ public sealed partial class CCVars
     ///     Prototype to use for map pool.
     /// </summary>
     public static readonly CVarDef<string>
-        GameMapPool = CVarDef.Create("game.map_pool", "ProspectMapPool", CVar.SERVERONLY); // Prospect: DefaultMapPool<ProspectMapPool
+        GameMapPool = CVarDef.Create("game.map_pool", "PSDefaultMapPool", CVar.SERVERONLY); // Prospect: DefaultMapPool<PSDefaultMapPool
 
     /// <summary>
     ///     The depth of the queue used to calculate which map is next in rotation.

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -88,7 +88,7 @@ public sealed partial class CCVars
     ///     Prototype to use for map pool.
     /// </summary>
     public static readonly CVarDef<string>
-        GameMapPool = CVarDef.Create("game.map_pool", "DefaultMapPool", CVar.SERVERONLY);
+        GameMapPool = CVarDef.Create("game.map_pool", "ProspectMapPool", CVar.SERVERONLY); // Prospect: DefaultMapPool<ProspectMapPool
 
     /// <summary>
     ///     The depth of the queue used to calculate which map is next in rotation.

--- a/Content.Shared/CCVar/CCVars.Misc.cs
+++ b/Content.Shared/CCVar/CCVars.Misc.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Configuration;
+using Robust.Shared.Configuration;
 
 namespace Content.Shared.CCVar;
 
@@ -84,7 +84,7 @@ public sealed partial class CCVars
         CVarDef.Create("entgc.maximum_time_ms", 5, CVar.SERVERONLY);
 
     public static readonly CVarDef<bool> GatewayGeneratorEnabled =
-        CVarDef.Create("gateway.generator_enabled", true);
+        CVarDef.Create("gateway.generator_enabled", false); // Prospect: true<false
 
     public static readonly CVarDef<string> TippyEntity =
         CVarDef.Create("tippy.entity", "Tippy", CVar.SERVER | CVar.REPLICATED);

--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Administration;
+using Content.Shared.Administration;
 using Content.Shared.CCVar.CVarAccess;
 using Robust.Shared.Configuration;
 
@@ -74,7 +74,7 @@ public sealed partial class CCVars
     ///     Whether to automatically preloading grids by GridPreloaderSystem
     /// </summary>
     public static readonly CVarDef<bool> PreloadGrids =
-        CVarDef.Create("shuttle.preload_grids", true, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.preload_grids", false, CVar.SERVERONLY); // Prospect: true<false
 
     /// <summary>
     ///     How long the warmup time before FTL start should be.

--- a/Resources/Prototypes/_PS/Maps/Pools/default.yml
+++ b/Resources/Prototypes/_PS/Maps/Pools/default.yml
@@ -1,0 +1,4 @@
+- type: gameMapPool
+  id: PSDefaultMapPool
+  maps:
+  - Prospect


### PR DESCRIPTION
## About the PR
This pull request updates several configuration variables and adds a new map pool prototype to support a new default map pool setup for the game. The changes primarily affect which map pool is used by default, and toggle a few server-related features.

**Configuration updates:**

* Changed the default value of `GameMapPool` from `"DefaultMapPool"` to `"PSDefaultMapPool"` to use a new map pool prototype.
* Set `GatewayGeneratorEnabled` to `false` by default, disabling the gateway generator unless explicitly enabled.
* Set `PreloadGrids` to `false` by default, disabling automatic grid preloading.

**Changelog**
:cl:
- tweak: Updated map pool config.
